### PR TITLE
Allow PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "symfony/intl": "^4.1 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates composer.json to allow installing the package on PHP 8.

Should I update `.travis.yml` to run the tests on PHP 8?